### PR TITLE
Add actions workflow with invalid environment variable to test filtering

### DIFF
--- a/.github/workflows/ci-invalid-env.yml
+++ b/.github/workflows/ci-invalid-env.yml
@@ -1,4 +1,5 @@
-name: CI
+name: CI-Invalid-Env
+# This workflow is used to test the invalid environment variable handling in the GitHub Actions runner.
 
 on: [push]
 

--- a/.github/workflows/ci-invalid-env.yml
+++ b/.github/workflows/ci-invalid-env.yml
@@ -1,0 +1,31 @@
+name: CI
+
+on: [push]
+
+jobs:
+  build-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up invalid environment variable
+        run: |
+          echo 'MULTI_LINE_ENV<<EOF' >> $GITHUB_ENV
+          echo 'MULTI_LINE_ENV=LINE 1' >> $GITHUB_ENV
+          echo 'LINE 2' >> $GITHUB_ENV
+          echo 'LINE 3' >> $GITHUB_ENV
+          echo 'LINE 4' >> $GITHUB_ENV
+          echo 'EOF' >> $GITHUB_ENV
+
+      - uses: php-actions/composer@v6
+
+      - name: PHPUnit Tests
+        uses: php-actions/phpunit@master
+        env:
+          TEST_NAME: Scarlett
+        with:
+          version: 9.6
+          bootstrap: vendor/autoload.php
+          configuration: test/phpunit.xml
+          args: --coverage-text

--- a/.github/workflows/ci-invalid-env.yml
+++ b/.github/workflows/ci-invalid-env.yml
@@ -18,10 +18,10 @@ jobs:
           echo 'LINE 4' >> $GITHUB_ENV
           echo 'EOF' >> $GITHUB_ENV
 
-      - uses: php-actions/composer@v6
+      - uses: BradleyGoulding/composer@master
 
       - name: PHPUnit Tests
-        uses: php-actions/phpunit@master
+        uses: BradleyGoulding/phpunit@master
         env:
           TEST_NAME: Scarlett
         with:


### PR DESCRIPTION
Adds a test to validate the following issues
https://github.com/php-actions/phpunit/issues/75
 https://github.com/php-actions/composer/issues/128

This will require both PRs 
https://github.com/php-actions/composer/pull/129
https://github.com/php-actions/phpunit/pull/76

The test is a simple action that just pre-sets a malformed env var

The commit b41bc94066ee04f845ace25291d72b7c5d437a35 uses my patched versions from the PRs
I cannot use the current release versions as this will cause this test to fail.